### PR TITLE
Added additional post-install caution

### DIFF
--- a/www/clonos/files/pkg-message.in
+++ b/www/clonos/files/pkg-message.in
@@ -128,6 +128,12 @@ stream {
 
     Or copy: cp %%PREFIX%%/etc/nginx/nginx.conf.clonos.sample %%PREFIX%%/etc/nginx/nginx.conf
 
+[*] Make sure %%PREFIX%%/etc/nginx/sites-enabled/cbsdweb.conf
+    have correct path to CBSD workdir. Please check that line "fastcgi_param WORKDIR.."
+    in %%PREFIX%%/etc/nginx/sites-enabled/cbsdweb.conf pointed to ~cbsd path:
+
+    fastcgi_param WORKDIR /usr/jails;
+                          ^^^^^^^^^^
 [*] Enable nginx, php-fpm and supervisord to run at system startup:
 
 sysrc nginx_enable="YES"


### PR DESCRIPTION
The statement `fastcgi_param WORKDIR` in `%%PREFIX%%/etc/nginx/sites-enabled/cbsdweb.conf` should be checked especially when special CBSD workdir is specified.
Currently there's no caution about this statement and it should be shown.