### PR TITLE
clonos: fix an error of copy and paste

### DIFF
--- a/www/clonos/files/pkg-message.in
+++ b/www/clonos/files/pkg-message.in
@@ -68,7 +68,7 @@ www   ALL=(ALL) NOPASSWD:SETENV: WEB_CMD
 chown root:wheel %%PREFIX%%/etc/sudoers.d/10_www
 chmod 0440 %%PREFIX%%/etc/sudoers.d/10_www
 
-    Or copy: cp %%PREFIX%%/etc/sudoers_10_www.clonos.sample cp %%PREFIX%%/etc/sudoers.d/10_www
+    Or copy: cp %%PREFIX%%/etc/sudoers_10_www.clonos.sample %%PREFIX%%/etc/sudoers.d/10_www
 
 
 [*] Enable and start websocket daemon:


### PR DESCRIPTION
Hi,

I just tested ClonOS 21.10 in HardenedBSD 13.0. I noticed this little copy and paste error while reading the installation message.

Thanks.